### PR TITLE
[WIP]add developer guide

### DIFF
--- a/docker.local/Dockerfile
+++ b/docker.local/Dockerfile
@@ -36,6 +36,9 @@ RUN go build -v -tags "bn256 development" -ldflags "-X 0chain.net/core/build.Bui
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.11.4-alpine3.8
+
+LABEL zchain="0dns"
+
 ENV APP_DIR=/0dns
 WORKDIR $APP_DIR
 RUN apk add gmp gmp-dev openssl-dev

--- a/docker.local/bin/build.sh
+++ b/docker.local/bin/build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-docker-compose -p 0dns -f docker.local/docker-compose.yml build --force-rm
+#mount volumns
+
+VOLUMES_CONFIG=./config VOLUMES_LOG=./0dns/log VOLUMES_MONGO_DATA=./0dns/mongodata docker-compose -p 0dns -f docker.local/docker-compose.yml build --force-rm
 docker.local/bin/sync_clock.sh

--- a/docker.local/dev-docker-compose.yml
+++ b/docker.local/dev-docker-compose.yml
@@ -3,7 +3,7 @@ services:
   mongodb:
     image: mongo
     volumes:
-      - ./0dns/mongodata:/data/db
+      - ${VOLUMES_MONGO_DATA}:/data/db
     networks:
       default:
       testnet0:
@@ -22,8 +22,8 @@ services:
     links:
       - mongodb:mongodb
     volumes:
-      - ./config:/0dns/config
-      - ./0dns/log:/0dns/log
+      - ${VOLUMES_CONFIG}:/0dns/config
+      - ${VOLUMES_LOG}:/0dns/log
     ports:
       - "9091:9091"
     labels:

--- a/docker.local/docker-compose.yml
+++ b/docker.local/docker-compose.yml
@@ -3,13 +3,14 @@ services:
   mongodb:
     image: mongo
     volumes:
-      - ./0dns/mongodata:/data/db
+      - ${VOLUMES_MONGO_DATA}:/data/db
     networks:
       default:
       testnet0:
     ports:
       - "27017:27017"
-
+    labels:
+      zchain: "mongo"
   0dns:
     environment:
       - DOCKER=true
@@ -21,10 +22,12 @@ services:
     links:
       - mongodb:mongodb
     volumes:
-      - ./config:/0dns/config
-      - ./0dns/log:/0dns/log
+      - ${VOLUMES_CONFIG}:/0dns/config
+      - ${VOLUMES_LOG}:/0dns/log
     ports:
       - "9091:9091"
+    labels:
+      zchain: "0dns"
     networks:
       default:
       testnet0:


### PR DESCRIPTION
it is linked to 0chain's issue https://github.com/0chain/0chain/issues/287

- Local dev env will be setup in only one folder : ~/0chain/quickstart/dev.local/data .It will be easier to check all things
- added lable "zchain" to docker image and container. it let us easy to start/stop/rm them
```
docker rm `docker ps -aq -f "label=zchain"
```

