### PR TITLE
Split mutable config into global state

### DIFF
--- a/code/go/0dns.io/core/config/config.go
+++ b/code/go/0dns.io/core/config/config.go
@@ -2,12 +2,8 @@ package config
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
-
-	"0dns.io/core/logging"
-	"github.com/0chain/gosdk/core/block"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 //SetupDefaultConfig - setup the default config options that can be overridden via the config file
@@ -38,8 +34,6 @@ const (
 	DeploymentDevelopment = 0
 	DeploymentTestNet     = 1
 	DeploymentMainNet     = 2
-	HTTPProtocol          = "http://"
-	HTTPSProtocol         = "https://"
 )
 
 /*Config - all the config options passed from the command line*/
@@ -48,15 +42,11 @@ type Config struct {
 	ChainID         string
 	DeploymentMode  byte
 	SignatureScheme string
-	Miners          []string
-	Sharders        []string
 
 	MagicBlockWorkerTimerInSeconds int64
 
 	UseHTTPS bool
 	UsePath  bool
-
-	CurrentMagicBlock *block.MagicBlock
 }
 
 /*Configuration of the system */
@@ -70,68 +60,4 @@ func TestNet() bool {
 /*Development - is the programming running in development mode? */
 func Development() bool {
 	return Configuration.DeploymentMode == DeploymentDevelopment
-}
-
-func (c *Config) UpdateMagicBlock(m *block.MagicBlock) {
-	c.CurrentMagicBlock = m
-}
-
-func (c *Config) SetMinerSharderNodes() {
-	if c.CurrentMagicBlock == nil {
-		panic("No magic block set")
-	}
-
-	networkProtocol := HTTPProtocol
-	if c.UseHTTPS {
-		networkProtocol = HTTPSProtocol
-	}
-
-	var miners []string
-	for _, miner := range c.CurrentMagicBlock.Miners.Nodes {
-		host := miner.Host
-		if strings.Contains(host, "localhost") {
-			host = miner.N2NHost
-		}
-
-		if c.UsePath {
-			miners = append(miners,
-				networkProtocol+
-					host+
-					"/"+
-					miner.Path)
-		} else {
-			miners = append(miners,
-				networkProtocol+
-					host+
-					":"+
-					strconv.Itoa(miner.Port))
-		}
-	}
-
-	var sharders []string
-	for _, sharder := range c.CurrentMagicBlock.Sharders.Nodes {
-		host := sharder.Host
-		if strings.Contains(host, "localhost") {
-			host = sharder.N2NHost
-		}
-		if c.UsePath {
-			sharders = append(sharders,
-				networkProtocol+
-					host+
-					"/"+
-					sharder.Path)
-		} else {
-			sharders = append(sharders,
-				networkProtocol+
-					host+
-					":"+
-					strconv.Itoa(sharder.Port))
-		}
-	}
-
-	c.Miners = miners
-	c.Sharders = sharders
-
-	logging.Logger.Info("miners: " + strings.Join(miners, ", "))
-	logging.Logger.Info("sharders: " + strings.Join(sharders, ", "))
 }

--- a/code/go/0dns.io/core/state/state.go
+++ b/code/go/0dns.io/core/state/state.go
@@ -1,0 +1,102 @@
+package state
+
+import (
+	"0dns.io/core/config"
+	"0dns.io/core/logging"
+	"github.com/0chain/gosdk/core/block"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	HTTPProtocol  = "http://"
+	HTTPSProtocol = "https://"
+)
+
+// State defines the latest state of network based on most recent magic block.
+type State struct {
+	sync.RWMutex
+	Miners            []string
+	Sharders          []string
+	CurrentMagicBlock *block.MagicBlock
+}
+
+// state is a global status of 0dns.
+var state = &State{}
+
+// Get return a copy of state.
+func Get() State {
+	state.RLock()
+	defer state.RUnlock()
+
+	return State{
+		Miners:            state.Miners,
+		Sharders:          state.Sharders,
+		CurrentMagicBlock: state.CurrentMagicBlock,
+	}
+}
+
+func SetFromCurrentMagicBlock(c config.Config, b *block.MagicBlock) {
+	if b == nil {
+		panic("Unexpected missing magic block")
+	}
+
+	networkProtocol := HTTPProtocol
+	if c.UseHTTPS {
+		networkProtocol = HTTPSProtocol
+	}
+
+	var miners []string
+	for _, miner := range b.Miners.Nodes {
+		host := miner.Host
+		if strings.Contains(host, "localhost") {
+			host = miner.N2NHost
+		}
+
+		if c.UsePath {
+			miners = append(miners,
+				networkProtocol+
+					host+
+					"/"+
+					miner.Path)
+		} else {
+			miners = append(miners,
+				networkProtocol+
+					host+
+					":"+
+					strconv.Itoa(miner.Port))
+		}
+	}
+
+	var sharders []string
+	for _, sharder := range b.Sharders.Nodes {
+		host := sharder.Host
+		if strings.Contains(host, "localhost") {
+			host = sharder.N2NHost
+		}
+		if c.UsePath {
+			sharders = append(sharders,
+				networkProtocol+
+					host+
+					"/"+
+					sharder.Path)
+		} else {
+			sharders = append(sharders,
+				networkProtocol+
+					host+
+					":"+
+					strconv.Itoa(sharder.Port))
+		}
+	}
+
+	logging.Logger.Info("miners: " + strings.Join(miners, ", "))
+	logging.Logger.Info("sharders: " + strings.Join(sharders, ", "))
+
+	state.Lock()
+	defer state.Unlock()
+
+	state.CurrentMagicBlock = b
+	state.Miners = miners
+	state.Sharders = sharders
+}

--- a/code/go/0dns.io/core/state/state_test.go
+++ b/code/go/0dns.io/core/state/state_test.go
@@ -60,10 +60,6 @@ func TestSetFromCurrentMagicBlock(t *testing.T) {
 		},
 	}
 
-	state.Miners = wantMiners
-	state.Sharders = wantSharders
-	state.CurrentMagicBlock = wantMagicBlock
-
 	SetFromCurrentMagicBlock(config.Config{}, wantMagicBlock)
 	got := Get()
 

--- a/code/go/0dns.io/core/state/state_test.go
+++ b/code/go/0dns.io/core/state/state_test.go
@@ -1,0 +1,73 @@
+package state
+
+import (
+	"0dns.io/core/config"
+	"0dns.io/core/logging"
+	"github.com/0chain/gosdk/core/block"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	wantMiners := []string{"test1", "test2"}
+	wantSharders := []string{"foo", "bar"}
+	wantMagicBlock := &block.MagicBlock{
+		Miners:   &block.NodePool{},
+		Sharders: &block.NodePool{},
+	}
+
+	state.Miners = wantMiners
+	state.Sharders = wantSharders
+	state.CurrentMagicBlock = wantMagicBlock
+
+	got := Get()
+
+	assert.Equal(t, wantMiners, got.Miners)
+	assert.Equal(t, wantSharders, got.Sharders)
+	assert.Equal(t, wantMagicBlock, got.CurrentMagicBlock)
+}
+
+func TestSetFromCurrentMagicBlock(t *testing.T) {
+	logging.InitLogging("development", os.TempDir())
+
+	wantMiners := []string{"http://dev.0chain.net:10001", "http://dev.0chain.net:10002"}
+	wantSharders := []string{"http://dev.0chain.net:20001", "http://dev.0chain.net:20002"}
+	wantMagicBlock := &block.MagicBlock{
+		Miners: &block.NodePool{
+			Nodes: map[string]block.Node{
+				"1": {
+					Host: "dev.0chain.net",
+					Port: 10001,
+				},
+				"2": {
+					Host: "dev.0chain.net",
+					Port: 10002,
+				},
+			},
+		},
+		Sharders: &block.NodePool{
+			Nodes: map[string]block.Node{
+				"1": {
+					Host: "dev.0chain.net",
+					Port: 20001,
+				},
+				"2": {
+					Host: "dev.0chain.net",
+					Port: 20002,
+				},
+			},
+		},
+	}
+
+	state.Miners = wantMiners
+	state.Sharders = wantSharders
+	state.CurrentMagicBlock = wantMagicBlock
+
+	SetFromCurrentMagicBlock(config.Config{}, wantMagicBlock)
+	got := Get()
+
+	assert.ElementsMatch(t, wantMiners, got.Miners)
+	assert.ElementsMatch(t, wantSharders, got.Sharders)
+	assert.Equal(t, wantMagicBlock, got.CurrentMagicBlock)
+}

--- a/code/go/0dns.io/go.mod
+++ b/code/go/0dns.io/go.mod
@@ -5,12 +5,14 @@ require (
 	github.com/didip/tollbooth v4.0.2+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/spf13/viper v1.11.0
+	github.com/stretchr/testify v1.7.1
 	go.uber.org/zap v1.21.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
 require (
 	github.com/0chain/errors v1.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -20,6 +22,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.0-beta.8 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect


### PR DESCRIPTION
## Proposed changes

Resolves https://github.com/0chain/0dns/issues/39

Split mutable config data (CurrentMagicBlock, Miners, Shareders) from static config data. Moved the mutable data to a synchronized global state to avoid race condition

Go test race.
```
(cd code/go/0dns.io && go test -race ./...)
?       0dns.io/core/common     [no test files]
?       0dns.io/core/config     [no test files]
?       0dns.io/core/logging    [no test files]
ok      0dns.io/core/state      0.783s
?       0dns.io/zdnscore/worker [no test files]
?       0dns.io/zdnscore/zdns   [no test files]
```

## Types of changes

What types of changes does your code introduce to **0dns**?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation Update 
- [ ] Other (Please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
