### PR TITLE
Upgrade 0Chain GoSDK to v1.8.4

### DIFF
--- a/code/go/0dns.io/go.mod
+++ b/code/go/0dns.io/go.mod
@@ -1,7 +1,7 @@
 module 0dns.io
 
 require (
-	github.com/0chain/gosdk v1.8.3
+	github.com/0chain/gosdk v1.8.4
 	github.com/didip/tollbooth v4.0.2+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/spf13/viper v1.11.0

--- a/code/go/0dns.io/go.sum
+++ b/code/go/0dns.io/go.sum
@@ -38,8 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.3 h1:L0H0TZcQY561RIVKpuB36FDFEyS/l6AzO7BNoYSVtB0=
-github.com/0chain/gosdk v1.8.3/go.mod h1:z7QHQwcdgAi8lhfdYCWkwKiZc1zOFre3x/jxnNgzh/M=
+github.com/0chain/gosdk v1.8.4 h1:cx+5NLUuRauF7Zs6g/UCDDoHav5JAVBpDY6p8zvWjGk=
+github.com/0chain/gosdk v1.8.4/go.mod h1:td58TBB5wrWGrULiXHQKNqqdoAmCtXtaERGB3bFIfYo=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=


### PR DESCRIPTION
0Chain GoSDK `v1.8.4` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/v1.8.4