### PR TITLE
Upgrade 0Chain GoSDK to v1.8.11

### DIFF
--- a/code/go/0dns.io/go.mod
+++ b/code/go/0dns.io/go.mod
@@ -1,7 +1,7 @@
 module 0dns.io
 
 require (
-	github.com/0chain/gosdk v1.8.10
+	github.com/0chain/gosdk v1.8.11
 	github.com/didip/tollbooth v4.0.2+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/spf13/viper v1.13.0

--- a/code/go/0dns.io/go.sum
+++ b/code/go/0dns.io/go.sum
@@ -38,8 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.10 h1:bQHfSWwxdMmQ0OhCiqCI29/V/wdGxiTvWamOPn9r+Ic=
-github.com/0chain/gosdk v1.8.10/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
+github.com/0chain/gosdk v1.8.11 h1:AWTVrTAU6i3csAJUMnjGIF8XjITYhKelUJgQek1hWcs=
+github.com/0chain/gosdk v1.8.11/go.mod h1:dVFY1d/++0d8QmcpKQvXvyaPa0cFC4TgVJ1uL6JBVOc=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=


### PR DESCRIPTION
0Chain GoSDK `v1.8.11` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/v1.8.11