### PR TITLE
added /dns route paath.

### DIFF
--- a/code/go/0dns.io/zdnscore/zdns/main.go
+++ b/code/go/0dns.io/zdnscore/zdns/main.go
@@ -64,6 +64,7 @@ func initHandlers(r *mux.Router) {
 	r.Use(useCors)
 
 	r.HandleFunc("/", common.UserRateLimit(HomePageHandler))
+	r.HandleFunc("/dns", common.UserRateLimit(HomePageHandler))
 	r.HandleFunc("/network", common.UserRateLimit(NetworkDetailsHandler))
 	r.HandleFunc("/magic_block", common.UserRateLimit(LatestMagicBlockHandler))
 }


### PR DESCRIPTION
added /dns route path. On mainnet we do not want to proxy the request via nginx because we already have a AWS loadbalancer before it.
Will remove the nginx service to remove the load from the server.