### PR TITLE
fix: use internal N2NHost URLs for magic block fetching

### DIFF
--- a/code/go/0dns.io/core/state/state.go
+++ b/code/go/0dns.io/core/state/state.go
@@ -17,8 +17,9 @@ const (
 // State defines the latest state of network based on most recent magic block.
 type State struct {
 	sync.RWMutex
-	Miners            []string
-	Sharders          []string
+	Miners            []string // External URLs (localhost) for serving to clients
+	Sharders          []string // External URLs (localhost) for serving to clients
+	InternalSharders  []string // Internal URLs (N2NHost) for fetching magic blocks
 	CurrentMagicBlock *block.MagicBlock
 }
 
@@ -33,6 +34,7 @@ func Get() State {
 	return State{
 		Miners:            state.Miners,
 		Sharders:          state.Sharders,
+		InternalSharders:  state.InternalSharders,
 		CurrentMagicBlock: state.CurrentMagicBlock,
 	}
 }
@@ -50,8 +52,11 @@ func SetFromCurrentMagicBlock(c config.Config, b *block.MagicBlock) {
 	var miners []string
 	for _, miner := range b.Miners.Nodes {
 		host := miner.Host
-		// Replace localhost with N2NHost unless use_localhost is enabled (for local dev)
-		if !c.UseLocalhost && (strings.Contains(host, "localhost") || strings.Contains(host, "127.0.0.1")) {
+		// When use_localhost is enabled, always use 127.0.0.1 for external URLs (local dev with port mappings)
+		// Otherwise, replace localhost with N2NHost for production
+		if c.UseLocalhost {
+			host = "127.0.0.1"
+		} else if strings.Contains(host, "localhost") || strings.Contains(host, "127.0.0.1") {
 			host = miner.N2NHost
 		}
 
@@ -71,16 +76,28 @@ func SetFromCurrentMagicBlock(c config.Config, b *block.MagicBlock) {
 	}
 
 	var sharders []string
+	var internalSharders []string
 	for _, sharder := range b.Sharders.Nodes {
+		// External URL: when use_localhost is enabled, always use 127.0.0.1 (local dev with port mappings)
 		host := sharder.Host
-		// Replace localhost with N2NHost unless use_localhost is enabled (for local dev)
-		if !c.UseLocalhost && (strings.Contains(host, "localhost") || strings.Contains(host, "127.0.0.1")) {
+		if c.UseLocalhost {
+			host = "127.0.0.1"
+		} else if strings.Contains(host, "localhost") || strings.Contains(host, "127.0.0.1") {
 			host = sharder.N2NHost
 		}
+
+		// Internal URL: always use N2NHost for fetching from container
+		internalHost := sharder.N2NHost
+
 		if c.UsePath {
 			sharders = append(sharders,
 				networkProtocol+
 					host+
+					"/"+
+					sharder.Path)
+			internalSharders = append(internalSharders,
+				networkProtocol+
+					internalHost+
 					"/"+
 					sharder.Path)
 		} else {
@@ -89,11 +106,17 @@ func SetFromCurrentMagicBlock(c config.Config, b *block.MagicBlock) {
 					host+
 					":"+
 					strconv.Itoa(sharder.Port))
+			internalSharders = append(internalSharders,
+				networkProtocol+
+					internalHost+
+					":"+
+					strconv.Itoa(sharder.Port))
 		}
 	}
 
 	logging.Logger.Info("miners: " + strings.Join(miners, ", "))
 	logging.Logger.Info("sharders: " + strings.Join(sharders, ", "))
+	logging.Logger.Info("internal sharders: " + strings.Join(internalSharders, ", "))
 
 	state.Lock()
 	defer state.Unlock()
@@ -101,4 +124,5 @@ func SetFromCurrentMagicBlock(c config.Config, b *block.MagicBlock) {
 	state.CurrentMagicBlock = b
 	state.Miners = miners
 	state.Sharders = sharders
+	state.InternalSharders = internalSharders
 }

--- a/code/go/0dns.io/zdnscore/worker/worker.go
+++ b/code/go/0dns.io/zdnscore/worker/worker.go
@@ -59,10 +59,17 @@ func GetMagicBlockByNumber(ctx context.Context, number int64) (m *block.MagicBlo
 func fetchMagicBlock(ctx context.Context, query string) (m *block.MagicBlock, err error) {
 	s := state.Get()
 
-	numSharders := len(s.Sharders)
+	// Use InternalSharders for fetching (N2NHost addresses work from container)
+	sharders := s.InternalSharders
+	if len(sharders) == 0 {
+		// Fallback to regular Sharders if InternalSharders not set
+		sharders = s.Sharders
+	}
+
+	numSharders := len(sharders)
 	var result = make(chan *util.GetResponse, numSharders)
 	defer close(result)
-	queryMagicBlockFromSharders(ctx, query, s.Sharders, result)
+	queryMagicBlockFromSharders(ctx, query, sharders, result)
 
 	var (
 		maxConsensus   int

--- a/docker.local/docker-compose.yml
+++ b/docker.local/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   0dns:
-    image: 0chaindev/0dns:staging
+    build:
+      context: ../
+      dockerfile: ./docker.local/Dockerfile
     environment:
       - DOCKER=true
     volumes:
@@ -10,14 +12,11 @@ services:
     ports:
       - "9091:9091"
     networks:
-      default:
       testnet0:
         ipv4_address: 198.18.0.98
     command: ./bin/zdns --deployment_mode 0 --magic_block /0dns/config/b0magicBlock.json
 
 networks:
-  default:
-    driver: bridge
   testnet0:
     external: true
 


### PR DESCRIPTION
## Summary
- Add `InternalSharders` field to State for fetching magic blocks via N2NHost
- When `use_localhost` is enabled, always use `127.0.0.1` for external URLs (API)
- Worker uses internal N2NHost addresses to fetch magic blocks from container

## Problem
0dns running in Docker couldn't fetch magic blocks because it tried to reach `127.0.0.1` from inside the container, which doesn't work (localhost inside container ≠ host).

## Solution
Separate URL handling:
- **External URLs** (served to clients via `/network`): Use `127.0.0.1` when `use_localhost: true`
- **Internal URLs** (used by worker to fetch MBs): Always use N2NHost addresses

## Test plan
- [x] Start local chain with miners/sharders
- [x] Start 0dns with `use_localhost: true`
- [x] Verify `/network` returns localhost URLs
- [x] Verify magic block fetch succeeds (check logs for "Magic block updated successfully")
- [x] Trigger view change and verify 0dns updates network info